### PR TITLE
Fixed bug in get_cloud_data when clouds value is 0

### DIFF
--- a/sky_alert/openweather_service.py
+++ b/sky_alert/openweather_service.py
@@ -116,7 +116,7 @@ class OpenweatherService:
             for i in range(HOURS_IN_DAY):
                 current_hourly_cloud_data = current_data[i].get("clouds")
 
-                if current_hourly_cloud_data:
+                if current_hourly_cloud_data is not None:
                     cloud_data.append(current_hourly_cloud_data)
                 else:
                     raise KeyError(


### PR DESCRIPTION
# Description

Quick bug fix. `get_cloud_data` was throwing a KeyError whenever the value of clouds was 0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).


